### PR TITLE
v0.3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: manynet
 Title: Many Ways to Make, Modify, and Map Myriad Networks
-Version: 0.3.0
-Date: 2023-12-15
+Version: 0.3.1
+Date: 2023-12-17
 Description: A set of tools for making, modifying, and mapping many different types of networks.
    All functions operate with matrices, edge lists, and 'igraph', 'network', and 'tidygraph' objects,
    and on one-mode, two-mode (bipartite), and sometimes three-mode networks.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+# manynet 0.3.1
+
+2023-12-17
+
+## Making
+
+* `as_tidygraph.diff_model()` no longer creates names for unlabelled networks
+
+## Modifying
+
+* `to_waves.diff_model()` now adds three logical vectors as variables, "Infected", "Exposed", and "Recovered"
+  - Relies on parallels to migraph's `node_is_latent()`, `node_is_infected()`, and `node_is_recovered()`
+
+## Mapping
+
+* `autographr()` now shapes seed, adopter, and non-adopter nodes using a parallel to migraph's `node_adoption_time()` for 
+  - Improved guide/legend labelling and positioning
+* `autographs()` now colors susceptible, exposed, infected, and recovered nodes correctly
+* `autographd()` now colors susceptible, exposed, infected, and recovered nodes correctly
+
 # manynet 0.3.0
 
 2023-12-15

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 ## Package
 
-* Overhaul of the README to summarise many of the unique aspects of the package
+* Overhaul of the README to summarise many of the unique aspects of the package (closed #36)
 
 ## Making
 
@@ -25,10 +25,10 @@ with `igraph::as_biadjacency_matrix()` and `igraph::graph_from_biadjacency_matri
 ## Mapping
 
 * `autographr()` now plots diff_model objects, showing the diffusion as a heatmap on the vertices
-* `autographs()` and `autographd()` now utilise network information in diff_model objects to provide better layouts 
+* `autographs()` and `autographd()` now utilise network information in diff_model objects to provide better layouts (closed #17)
 * Fixed bug with specifying `node_size` in `autographd()`
 * `many_palettes` replaces `iheid_palette`
-* Added new palettes, themes and scales for graphs
+* Added new palettes, themes and scales for graphs (closed #9)
   - `theme_ethz()`, `scale_color_ethz()`/`scale_colour_ethz()`, and `scale_fill_ethz()` for ETH Zürich
   - `theme_uzh()`, `scale_color_uzh()`/`scale_colour_uzh()`, and `scale_fill_uzh()` for Uni Zürich
   - `theme_rug()`, `scale_color_rug()`/`scale_colour_rug()`, and `scale_fill_rug()` for Uni Gröningen

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 
 * `to_waves.diff_model()` now adds three logical vectors as variables, "Infected", "Exposed", and "Recovered"
   - Relies on parallels to migraph's `node_is_latent()`, `node_is_infected()`, and `node_is_recovered()`
+  - Fixed bug in wave naming
 
 ## Mapping
 

--- a/R/make_as.R
+++ b/R/make_as.R
@@ -660,10 +660,10 @@ as_tidygraph.siena <- function(.data, twomode = FALSE) {
 as_tidygraph.diff_model <- function(.data, twomode = FALSE) {
   out <- as_tidygraph(attr(.data, "network"))
   attr(out, "diff_model") <- .data
-  if (!"name" %in% names(node_attribute(out))) {
-    out <- add_node_attribute(out, "name",
-                              as.character(seq_len(igraph::vcount(out))))
-  }
+  # if (!"name" %in% names(node_attribute(out))) {
+  #   out <- add_node_attribute(out, "name",
+  #                             as.character(seq_len(igraph::vcount(out))))
+  # }
   out
 }
 

--- a/R/manip_split.R
+++ b/R/manip_split.R
@@ -162,23 +162,27 @@ to_components.data.frame <- function(.data){
 #'   NULL by default.
 #'   That is, a list of networks for every available wave is returned.
 #'   Users can also list specific waves they want to select.
+#' @param cumulative Would you you like wave ties to be cumulative?
+#'   FALSE by default. That is, each wave is treated isolated.
 #' @examples
 #' ison_adolescents %>%
 #'   mutate_ties(wave = sample(1995:1998, 10, replace = TRUE)) %>%
 #'   to_waves(attribute = "wave")
 #' ison_adolescents %>%
 #'   mutate_ties(wave = sample(1995:1998, 10, replace = TRUE)) %>%
-#'   to_waves(attribute = "wave", panels = c(1995, 1996))
+#'   to_waves(attribute = "wave", panels = c(1995, 1996), cumulative = TRUE)
 #' @export
-to_waves <- function(.data, attribute = "wave", panels = NULL) UseMethod("to_waves")
+to_waves <- function(.data, attribute = "wave", panels = NULL,
+                     cumulative = FALSE) UseMethod("to_waves")
 
 #' @importFrom tidygraph to_subgraph as_tbl_graph
 #' @export
-to_waves.tbl_graph <- function(.data, attribute = "wave", panels = NULL) {
+to_waves.tbl_graph <- function(.data, attribute = "wave", panels = NULL,
+                               cumulative = FALSE) {
   wp <- unique(tie_attribute(.data, attribute))
   if(!is.null(panels))
     wp <- intersect(panels, wp)
-  if(length(wp)>1){
+  if(length(wp) > 1) {
     out <- lapply(wp, function(l){
       filter_ties(.data, !!as.name(attribute) == l)
     })
@@ -186,32 +190,39 @@ to_waves.tbl_graph <- function(.data, attribute = "wave", panels = NULL) {
   } else {
     out <- filter_ties(.data, !!as.name(attribute) == wp)
   }
-  out
-}
-
-#' @export
-to_waves.igraph <- function(.data, attribute = "wave", panels = NULL) {
-  out <- to_waves(as_tidygraph(.data))
-  if(length(out)>1){
-    lapply(out, function(o) as_igraph(0))  
-  } else as_igraph(out)
-}
-
-#' @export
-to_waves.data.frame <- function(.data, attribute = "wave", panels = NULL) {
-  wp <- unique(tie_attribute(.data, attribute))
-  if(!is.null(panels)) wp <- intersect(panels, wp)
-  if(length(wp)>1){
-    out <- lapply(wp, function(l) .data[,attribute == l])
-    names(out) <- wp
-  } else if(length(wp)>1) {
-    out <- .data[,attribute == wp]
+  if (isTRUE(cumulative)) {
+    out <- cummulative_ties(out, attribute)
   }
   out
 }
 
 #' @export
-to_waves.diff_model <- function(.data, attribute = "t", panels = NULL) {
+to_waves.igraph <- function(.data, attribute = "wave", panels = NULL,
+                            cumulative = FALSE) {
+  out <- to_waves(as_tidygraph(.data), attribute, panels, cumulative)
+  if(length(out) > 1) lapply(out, as_igraph) else as_igraph(out)
+}
+
+#' @export
+to_waves.data.frame <- function(.data, attribute = "wave", panels = NULL,
+                                cumulative = FALSE) {
+  wp <- unique(tie_attribute(.data, attribute))
+  if(!is.null(panels)) wp <- intersect(panels, wp)
+  if(length(wp) > 1) {
+    out <- lapply(wp, function(l) .data[,attribute == l])
+    names(out) <- wp
+  } else if(length(wp) > 1) {
+    out <- .data[,attribute == wp]
+  }
+  if (isTRUE(cumulative)) {
+    out <- cummulative_ties(out, attribute)
+  }
+  out
+}
+
+#' @export
+to_waves.diff_model <- function(.data, attribute = "t", panels = NULL,
+                                cumulative = FALSE) {
   if(!is.null(panels)) .data <- .data[.data[[attribute]] %in% panels,]
   if (length(unique(.data[["n"]])) > 1)
     stop("Please make sure diffusion has the same number of nodes for all time points.")
@@ -224,7 +235,52 @@ to_waves.diff_model <- function(.data, attribute = "t", panels = NULL) {
                                        rep("Exposed", .data$E[k + 1]),
                                        rep("Susceptible", .data$S[k + 1])))
   }
+  if (isTRUE(cumulative)) {
+    out <- cummulative_ties(out, attribute)
+  }
   out
+}
+
+cummulative_ties <- function(x, attribute) {
+  thisRequires("zoo")
+  thisRequires("purrr")
+  ties <- data.frame("to" = 0, "from" = 0, "wave" = 0, "order" = 0)
+  x <- lapply(x, as_tidygraph)
+  for (k in seq_len(length(names(x)))) {
+    a <- x[[k]] %>%
+      tidygraph::activate(edges) %>%
+      dplyr::as_tibble() %>%
+      dplyr::mutate(order = k) %>%
+      dplyr::select(to, from, dplyr::all_of(attribute), order)
+    ties <- rbind(ties, a)
+  }
+  ties <- ties[-1,]
+  if (is.numeric(ties[[attribute]])) {
+    ties <- ties[order(ties[[attribute]]),]
+    a <- list()
+    for (k in unique(ties[[attribute]])) {
+      if (k != unique(ties[[attribute]][1])) {
+        a[[as.character(k)]] <- subset(ties, ties[[attribute]] < k)[1:3]
+        a[[as.character(k)]][attribute] <- k
+      }
+    }
+  } else {
+    message("Cummulative ties were added based on order of appearance for attribute.")
+    a <- list()
+    for (k in unique(ties$order)) {
+      if (k != 1) {
+        a[[unique(ties[[attribute]][k])]] <- subset(ties, ties$order < k)[1:3]
+        a[[unique(ties[[attribute]][k])]][attribute] <- k
+      }
+    }
+  }
+  for (k in names(a)) {
+    x[[k]] <- igraph::add.edges(
+      x[[k]], c(a[[k]]$to, a[[k]]$from)[order(c(ceiling(seq_along(a[[k]]$to)/1),
+                                                seq_along(a[[k]]$from)))],
+      attr = a[[k]][3])
+  }
+  lapply(x, as_tidygraph)
 }
 
 #' @describeIn split Returns a list of a network

--- a/R/manip_split.R
+++ b/R/manip_split.R
@@ -168,9 +168,6 @@ to_components.data.frame <- function(.data){
 #' ison_adolescents %>%
 #'   mutate_ties(wave = sample(1995:1998, 10, replace = TRUE)) %>%
 #'   to_waves(attribute = "wave")
-#' ison_adolescents %>%
-#'   mutate_ties(wave = sample(1995:1998, 10, replace = TRUE)) %>%
-#'   to_waves(attribute = "wave", panels = c(1995, 1996), cumulative = TRUE)
 #' @export
 to_waves <- function(.data, attribute = "wave", panels = NULL,
                      cumulative = FALSE) UseMethod("to_waves")
@@ -310,6 +307,7 @@ to_waves.diff_model <- function(.data, attribute = "t", panels = NULL,
 }
 
 cumulative_ties <- function(x, attribute) {
+  edges <- to <- from <- NULL
   thisRequires("zoo")
   thisRequires("purrr")
   ties <- data.frame("to" = 0, "from" = 0, "wave" = 0, "order" = 0)

--- a/R/manip_split.R
+++ b/R/manip_split.R
@@ -227,7 +227,7 @@ to_waves.diff_model <- function(.data, attribute = "t", panels = NULL,
   diff <- .data
   out <- list()
   for (k in .data[[attribute]]) {
-    out[[paste0("Time: ", k)]] <- net %>%
+    out[[paste("Time:", formatC(k, width = max(nchar(.data[[attribute]])), flag = 0))]] <- net %>%
       tidygraph::mutate(Infected = .node_is_infected(diff, time = k),
                         Exposed = .node_is_latent(diff, time = k),
                         Recovered = .node_is_recovered(diff, time = k))# |>

--- a/R/manip_split.R
+++ b/R/manip_split.R
@@ -162,7 +162,7 @@ to_components.data.frame <- function(.data){
 #'   NULL by default.
 #'   That is, a list of networks for every available wave is returned.
 #'   Users can also list specific waves they want to select.
-#' @param cumulative Would you you like wave ties to be cumulative?
+#' @param cumulative Whether to make wave ties cumulative.
 #'   FALSE by default. That is, each wave is treated isolated.
 #' @examples
 #' ison_adolescents %>%
@@ -191,7 +191,7 @@ to_waves.tbl_graph <- function(.data, attribute = "wave", panels = NULL,
     out <- filter_ties(.data, !!as.name(attribute) == wp)
   }
   if (isTRUE(cumulative)) {
-    out <- cummulative_ties(out, attribute)
+    out <- cumulative_ties(out, attribute)
   }
   out
 }
@@ -215,7 +215,7 @@ to_waves.data.frame <- function(.data, attribute = "wave", panels = NULL,
     out <- .data[,attribute == wp]
   }
   if (isTRUE(cumulative)) {
-    out <- cummulative_ties(out, attribute)
+    out <- cumulative_ties(out, attribute)
   }
   out
 }

--- a/R/map_autographr.R
+++ b/R/map_autographr.R
@@ -615,8 +615,9 @@ reduce_categories <- function(g, node_group) {
   nsize <- .infer_nsize(g, node_size)
   nshape <- .infer_shape(g, node_shape)
   if ("Infected" %in% names(node_attribute(g))) {
-    node_color <- as.factor(ifelse(node_attribute(g, "Infected"),
-                                   "Infected", "Susceptible"))
+    node_color <- as.factor(ifelse(node_attribute(g, "Exposed"), "Exposed",
+                                   ifelse(node_attribute(g, "Infected"),"Infected", 
+                                   "Susceptible")))
     p <- p + ggraph::geom_node_point(ggplot2::aes(color = node_color),
                                      size = nsize, shape = nshape) +
       ggplot2::scale_color_manual(name = NULL, guide = "none",

--- a/R/map_autographr.R
+++ b/R/map_autographr.R
@@ -617,7 +617,8 @@ reduce_categories <- function(g, node_group) {
   if ("Infected" %in% names(node_attribute(g))) {
     node_color <- as.factor(ifelse(node_attribute(g, "Exposed"), "Exposed",
                                    ifelse(node_attribute(g, "Infected"),"Infected", 
-                                   "Susceptible")))
+                                          ifelse(node_attribute(g, "Recovered"), "Recovered",
+                                                 "Susceptible"))))
     p <- p + ggraph::geom_node_point(ggplot2::aes(color = node_color),
                                      size = nsize, shape = nshape) +
       ggplot2::scale_color_manual(name = NULL, guide = "none",

--- a/R/map_autographr.R
+++ b/R/map_autographr.R
@@ -624,9 +624,9 @@ reduce_categories <- function(g, node_group) {
                                              "Exposed" = "orange",
                                              "Recovered" = "darkgreen"))
   } else if (any("diff_model" %in% names(attributes(g)))) {
-    nshape <- ifelse(node_color == 0, "Not Adopted",
-                     ifelse(node_color == 1, "Seed(s)", "Adopted"))
     node_adopts <- .node_adoption_time(g)
+    nshape <- ifelse(node_adopts == min(node_adopts), "Seed(s)",
+                     ifelse(node_adopts == Inf, "Non-Adopter", "Adopter"))
     node_color <- ifelse(is.infinite(node_adopts), 
                          max(node_adopts[!is.infinite(node_adopts)]) + 1, 
                          node_adopts)
@@ -634,14 +634,17 @@ reduce_categories <- function(g, node_group) {
                                                   color = node_color),
                                      size = nsize) +
       ggplot2::scale_color_gradient(low = "red", high = "blue",
-                                    breaks=c(1, max(node_color)),
-                                    labels=c("Early adoption", "Late adoption"),
-                                    name = "Time of\nAdoption") +
+                                    breaks=c(min(node_color)+1, 
+                                             ifelse(any(nshape=="Non-Adopter"),
+                                                    max(node_color)-1,
+                                                    max(node_color))),
+                                    labels=c("Early\nadoption", "Late\nadoption"),
+                                    name = "Time of\nAdoption\n") +
       ggplot2::scale_shape_manual(name = "",
-                                  breaks = c("Seed(s)", "Adopted", "Not Adopted"),
+                                  breaks = c("Seed(s)", "Adopter", "Non-Adopter"),
                                   values = c("Seed(s)" = "triangle",
-                                             "Adopted" = "circle",
-                                             "Not Adopted" = "square")) +
+                                             "Adopter" = "circle",
+                                             "Non-Adopter" = "square")) +
       ggplot2::guides(color = ggplot2::guide_colorbar(order = 1, reverse = TRUE),
                       shape = ggplot2::guide_legend(order = 2))
   } else {

--- a/R/map_autographr.R
+++ b/R/map_autographr.R
@@ -882,7 +882,8 @@ time_edges_lst <- function(tlist, edges_lst, nodes_lst, edge_color) {
   })
   # Keep only necessary columns
   edg <- lapply(edg, function (x) x[,c("from", "to", "frame", "x", "y", "xend",
-                                       "yend", "id", "status", edge_color)])
+                                       "yend", "id", "status"#, edge_color
+                                       )])
 }
 
 transition_edge_lst <- function(tlist, edges_lst, nodes_lst, all_edges) {
@@ -975,10 +976,14 @@ map_dynamic <- function(edges_out, nodes_out, edge_color, node_shape,
       }
     }
   } else if (is.null(node_color) & "Infected" %in% names(nodes_out)) {
+    node_color <- as.factor(ifelse(nodes_out[["Exposed"]], "Exposed",
+                                   ifelse(nodes_out[["Infected"]],"Infected", 
+                                          ifelse(nodes_out[["Recovered"]], "Recovered",
+                                                 "Susceptible"))))
     # node_color <- ifelse(nodes_out[["Infected"]] == "Infected", "red",
     #                      ifelse(nodes_out[["Infected"]] == "Susceptible", "blue",
     #                             ifelse(nodes_out[["Infected"]] == "Exposed", "orange", "darkgreen")))
-    node_color <- ifelse(nodes_out[["Infected"]], "Infected", "Susceptible")
+    # node_color <- ifelse(nodes_out[["Infected"]], "Infected", "Susceptible")
   } else node_color <- "darkgray"
   if (!is.null(node_size)) {
     if (node_size %in% names(nodes_out)) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -198,10 +198,11 @@ Below is a directed graph showing the currently available options:
 
 ![](https://www.jameshollway.com/post/manynet/README-coercion-graph-1.png)
 
-```{r coercion-graph, echo = FALSE, dpi = 300, eval = FALSE}
+```{r coercion-graph, echo = FALSE, dpi = 300, eval=FALSE}
 autographr(igraph::graph_from_literal(edgelist:matrix:igraph:network:tidygraph+--+edgelist:matrix:igraph:network:tidygraph,
                                       edgelist:matrix:igraph:network:tidygraph--+graphAM,
                                       tidygraph:igraph--+siena,
+                                      diff_model--+tidygraph,
                                       siena:goldfish--+edgelist:matrix:igraph:network:tidygraph:graphAM),
            "circle", node_size = 4)
 ```

--- a/man/split.Rd
+++ b/man/split.Rd
@@ -15,7 +15,7 @@ to_subgraphs(.data, attribute)
 
 to_components(.data)
 
-to_waves(.data, attribute = "wave", panels = NULL)
+to_waves(.data, attribute = "wave", panels = NULL, cumulative = FALSE)
 
 to_slices(.data, attribute = "time", slice = NULL)
 }
@@ -43,6 +43,9 @@ and 2 excludes ego's direct alters.}
 NULL by default.
 That is, a list of networks for every available wave is returned.
 Users can also list specific waves they want to select.}
+
+\item{cumulative}{Would you you like wave ties to be cumulative?
+FALSE by default. That is, each wave is treated isolated.}
 
 \item{slice}{Character string or character list indicating the date(s)
 or integer(s) range used to slice data (e.g slice = c(1:2, 3:4)).}
@@ -96,7 +99,7 @@ ison_adolescents \%>\%
   to_waves(attribute = "wave")
 ison_adolescents \%>\%
   mutate_ties(wave = sample(1995:1998, 10, replace = TRUE)) \%>\%
-  to_waves(attribute = "wave", panels = c(1995, 1996))
+  to_waves(attribute = "wave", panels = c(1995, 1996), cumulative = TRUE)
 ison_adolescents \%>\%
   mutate_ties(time = 1:10, increment = 1) \%>\% 
   add_ties(c(1,2), list(time = 3, increment = -1)) \%>\% 

--- a/man/split.Rd
+++ b/man/split.Rd
@@ -98,9 +98,6 @@ ison_adolescents \%>\%
   mutate_ties(wave = sample(1995:1998, 10, replace = TRUE)) \%>\%
   to_waves(attribute = "wave")
 ison_adolescents \%>\%
-  mutate_ties(wave = sample(1995:1998, 10, replace = TRUE)) \%>\%
-  to_waves(attribute = "wave", panels = c(1995, 1996), cumulative = TRUE)
-ison_adolescents \%>\%
   mutate_ties(time = 1:10, increment = 1) \%>\% 
   add_ties(c(1,2), list(time = 3, increment = -1)) \%>\% 
   to_slices(slice = 7)

--- a/man/split.Rd
+++ b/man/split.Rd
@@ -44,7 +44,7 @@ NULL by default.
 That is, a list of networks for every available wave is returned.
 Users can also list specific waves they want to select.}
 
-\item{cumulative}{Would you you like wave ties to be cumulative?
+\item{cumulative}{Whether to make wave ties cumulative.
 FALSE by default. That is, each wave is treated isolated.}
 
 \item{slice}{Character string or character list indicating the date(s)


### PR DESCRIPTION
# Description

## Making

* `as_tidygraph.diff_model()` no longer creates names for unlabelled networks

## Modifying

* `to_waves.diff_model()` now adds three logical vectors as variables, "Infected", "Exposed", and "Recovered"
  - Relies on parallels to migraph's `node_is_latent()`, `node_is_infected()`, and `node_is_recovered()`

## Mapping

* `autographr()` now shapes seed, adopter, and non-adopter nodes using a parallel to migraph's `node_adoption_time()` for 
  - Improved guide/legend labelling and positioning
* `autographs()` now colors susceptible, exposed, infected, and recovered nodes correctly
* `autographd()` now colors susceptible, exposed, infected, and recovered nodes correctly

# Checklist:

- PR form
  - [x] Description above itemizes changes under subtitles, e.g. "## Data""
  - [x] Any closed, fixed, or related issues are referenced and explained in the description above, e.g. "Fixed #0 by adding A"
  - [x] Package builds on my OS without issues
- PR checks all pass for latest commit
  - [x] CodeFactor check: Package improves or maintains good style
  - [x] Package builds on Mac
  - [x] Package builds on Windows
  - [x] Package builds on Linux
  - [ ] CodeCov check: Package improves or maintains good test coverage
- Documentation
  - [x] Any new or modified functions or data have roxygen style documentation in their .R scripts
  - [x] Longer functions are commented inline or broken down into helper functions so that it is easier to debug in the future
  - [x] PR description above and the NEWS.md file are aligned
  - [x] DESCRIPTION file version is bumped by the appropriate increment (major, minor, patch)
